### PR TITLE
Bug/sprintf format overflow in HashToRange

### DIFF
--- a/.task/common/memory-check.js
+++ b/.task/common/memory-check.js
@@ -32,7 +32,7 @@ function testWithMemoryCheck(dependencies, components) {
             executable
         ]
 
-        if (component == 'CryptID') {
+        if (component == 'CryptID' || component == 'SignID') {
             valgrindOptions.push('--', '--lowest-quick-check');
         }
 

--- a/src/CryptID.c
+++ b/src/CryptID.c
@@ -319,6 +319,8 @@ CryptidStatus cryptid_encrypt(CipherTextTuple *result, const char *const message
     free(rho);
     free(concat);
     free(z);
+    free(t);
+    free(w);
     free(cipherV);
     free(cipherW);
     free(hashedBytes);
@@ -413,6 +415,8 @@ CryptidStatus cryptid_decrypt(char **result, const AffinePoint privateKey, const
 
     complex_destroy(theta);
     free(z);
+    free(t);
+    free(w);
     free(rho);
     free(hashedBytes);
     free(concat);

--- a/src/util/Utils.c
+++ b/src/util/Utils.c
@@ -285,6 +285,7 @@ unsigned char* hashBytes(const int b, const unsigned char *const p, const int pL
 
     result[b] = '\0';
 
+    free(k);
     free(h);
     free(concat);
     free(resultPart);

--- a/src/util/Utils.c
+++ b/src/util/Utils.c
@@ -28,7 +28,7 @@ void hashToRange(mpz_t result, const unsigned char *const s, const int sLength, 
     h[hashLen] = '\0';
     unsigned char* t = (unsigned char*)calloc(hashLen + sLength + 1, sizeof(unsigned char));
     unsigned char* hexString = (unsigned char*)calloc(hashLen * 2 + 1, sizeof(unsigned char));
-    unsigned char hex[2];
+    unsigned char hex[3] = "\0\0\0";
 
     // {@code For i = 1 to 2, do:}
     for(int i = 1; i < 3; i++)


### PR DESCRIPTION
**Bug**

As it was reported in #18, there was something off with the `hashToRange` function. I tried to build it on Ubuntu 18.04 (64 bit) and got an error complaining about format overflow.

**Cause**

We might have built CryptID on a previous version of gcc where this warning was omitted (as format-overflow is a warning, but we use Wall and Wextra), and now it is default. The warning is caused by `hex` being too small to fit the terminator.

**Solution**

Increased the buffer size to 3.

**Notes**

Filling the buffer with zeros might not be necessary, but it's better to be in a known state. It's going to be optimized away by the compiler if unnecessary anyways.